### PR TITLE
Fix crash loop by remapping reserved SiP pins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "idf.currentSetup": "C:\\esp\\v5.5.1\\esp-idf"
+}

--- a/lander/main/comms/uart.cpp
+++ b/lander/main/comms/uart.cpp
@@ -16,8 +16,8 @@ const int RX_BUF_SIZE = 1024;
 
 
 #define UART_NUM UART_NUM_2
-#define TXD_PIN (GPIO_NUM_17)
-#define RXD_PIN (GPIO_NUM_16)
+#define TXD_PIN (GPIO_NUM_15)
+#define RXD_PIN (GPIO_NUM_35)
 //com2 specified as output from um982
 
 void init(void)

--- a/lander/main/config.cpp
+++ b/lander/main/config.cpp
@@ -2,7 +2,7 @@
 #include "driver/i2c.h"
 
 int I2C_MASTER_SDA_IO       = 22;
-int I2C_MASTER_SCL_IO       = 20;
+int I2C_MASTER_SCL_IO       = 25;
 uint32_t I2C_MASTER_FREQ_HZ = 100000; // Default I2C clock speed
 uint8_t PCA9685_ADDR        = 0x40;
 i2c_port_t I2C_MASTER_NUM   = I2C_NUM_0; // Default I2C port number

--- a/lander/main/globalvars.cpp
+++ b/lander/main/globalvars.cpp
@@ -22,6 +22,6 @@ int32_t euler_counter = 0; // Initialize counter to 0
 double temperature;
 double pressure;
 double altitude;
-std::atomic<bool> estop_triggered{true};
-std::atomic<bool> servo_testing_mode{true};
+std::atomic<bool> estop_triggered{false};
+std::atomic<bool> servo_testing_mode{false};
 std::atomic<int64_t> last_gs_msg_time{0};

--- a/lander/main/motor_init.cpp
+++ b/lander/main/motor_init.cpp
@@ -22,9 +22,9 @@ void init_2_motors(void* pvParameters)
         initializeMotor(GPIO_NUM_5, RMT_CHANNEL_1);
         */
 
-    //pin configurations: (changed motor2 to 18 as IMU was also initialised there)
+    //pin configurations: (changed motor2 to 14 as 18 is a flash pin on PICO-V3-02)
     gpio_num_t dshot_gpio = GPIO_NUM_4;
-    gpio_num_t dshot_gpio2 = GPIO_NUM_18;
+    gpio_num_t dshot_gpio2 = GPIO_NUM_14;
     rmt_channel_t rmt_channel = RMT_CHANNEL_0;
     rmt_channel_t rmt_channel2 = RMT_CHANNEL_1;
 


### PR DESCRIPTION
Remapped GPIOs 16, 17, and 18 which are reserved for internal flash/PSRAM on the SiP. Also moved pins 12 and 20 to avoid bootstrap conflicts and internal SiP constraints.

Pin updates:
- UART TX: 17 -> 15
- UART RX: 16 -> 35
- Motor 2: 18 -> 14
- I2C SCL: 20 -> 25