### PR TITLE
Prepare calibrated TVC control for tethered flight

### DIFF
--- a/lander/README.md
+++ b/lander/README.md
@@ -13,55 +13,224 @@ The current plan is to implement a Linear Quadratic Regulator for Full State Fee
 # Setup Guide
 1. Clone the repository by `git clone https://github.com/CUSF-Lander/lander-2.git --recurse-submodules`
 
-## Motor wiring
+## Current flight-test configuration
 
-The current counter-rotating propeller stack uses this DShot mapping:
+The committed defaults are for the first short-tether attitude-control test,
+not autonomous hover:
+
+| Compile-time option | Default | Behaviour |
+| --- | ---: | --- |
+| `SERVO_TERMINAL_TEST_MODE` | `0` | Isolated terminal-controlled servo test disabled |
+| `MOTOR_WIRING_TEST_MODE` | `0` | Combined 5% motor and servo-sweep test disabled |
+| `GIMBAL_ATTITUDE_MAPPING_TEST_MODE` | `0` | Direct 1:1 IMU-to-gimbal direction test disabled |
+| `MANUAL_THROTTLE_ATTITUDE_ONLY_MODE` | `1` | Ground-station motor throttle with closed-loop TVC attitude control enabled |
+| `MOTOR_REVERSE_BOTH_ON_STARTUP` | `0` | No temporary DShot motor reversal; the motor leads provide the required directions |
+
+In this configuration, the ground station commands equal collective throttle
+to both motors while the 50 Hz hover controller commands the two gimbal servos.
+Altitude control and horizontal-position control are deliberately excluded.
+
+## Hardware mapping and calibration
+
+### Motors
 
 | Propeller | ESP32 pin | ESC instance |
 | --- | ---: | --- |
 | Bottom | GPIO 4 | ESC 1 |
 | Top | GPIO 25 | ESC 2 |
 
-ESP-IDF 6 allocates RMT channels dynamically, so the application fixes the
-GPIO mapping but does not request channel numbers 0 and 1 directly.
+ESP-IDF 6 allocates RMT transmit channels dynamically. The application fixes
+the motor GPIOs but does not request hardware RMT channel numbers directly.
+Both ESCs are armed simultaneously with five seconds of zero-throttle DShot
+frames; this replaces the old sequential initialization in which the bottom
+propeller became ready about five seconds before the top propeller.
 
-With the previous sequential initialization, the bottom propeller initialized
-first and the top propeller initialized approximately five seconds later. The
-current implementation arms both ESCs simultaneously by sending zero-throttle
-DShot packets to both channels during the arming period.
+The motor leads are physically wired for the required counter-rotation.
+Temporary BLHeli DShot reversal commands remain available behind
+`MOTOR_REVERSE_BOTH_ON_STARTUP` for future bench configurations.
 
-The motor leads are now wired for the required directions. Temporary DShot
-reversal remains available in the firmware for future bench configurations, but
-`MOTOR_REVERSE_BOTH_ON_STARTUP` is disabled by default.
+### TVC servos
 
-For safety, both the firmware and ground-station throttle default to zero. The
-firmware rejects an ARM command while a nonzero throttle is stored, and an
-ESTOP resets the requested throttle to zero.
+| Controller gimbal | PCA9685 channel | Midpoint | Direction | Limited range |
+| --- | ---: | ---: | ---: | ---: |
+| Gimbal 1 | 0 | 110 degrees | Inverted | 97-123 degrees |
+| Gimbal 2 | 7 | 80 degrees | Inverted | 67-93 degrees |
 
-## Servo wiring
+The PCA9685 Servo FeatherWing uses the Feather's fixed I2C connection: SDA is
+GPIO 22 and SCL is GPIO 20. Controller outputs remain zero-centred radians.
+The actuator calibration converts them to physical servo angles as follows:
 
-The two TVC servos are connected to the PCA9685 Servo FeatherWing:
+```text
+channel 0 = 110 degrees - gimbal 1 deflection
+channel 7 =  80 degrees - gimbal 2 deflection
+```
 
-| Servo | PCA9685 channel |
-| --- | ---: |
-| TVC servo 1 | 0 |
-| TVC servo 2 | 7 |
+Both gimbal commands are initially limited to +/-13 degrees. The midpoints,
+direction multipliers, and limits are defined together in `globalvars.cpp` so
+they can be recalibrated without changing the controller's sign convention.
 
-The FeatherWing is hardwired to the Feather's I2C pins: SDA is GPIO 22 and SCL
-is GPIO 20. The temporary serial servo test is retained but disabled for the
-normal application build.
+A dedicated actuator task writes both servos at 50 Hz. The PCA9685 channels are
+fully off during startup and ESTOP, rather than continuing to emit a midpoint
+pulse. A successful ARM enables them. Invalid/non-finite angles or a failed
+servo write latch ESTOP, set motor throttle to zero, and disable both channels.
+
+## Expected startup, ARM, and ESTOP behaviour
+
+Normal startup performs the following sequence:
+
+1. Start in ESTOP with motor power set to zero.
+2. Enable the STEMMA QT/I2C power rail and initialize I2C and the PCA9685.
+3. Explicitly disable both TVC servo channels so stale PCA9685 outputs cannot
+   move the gimbal during sensor initialization.
+4. Initialize the BMP390 and average 20 stationary samples over approximately
+   one second to define launch altitude as zero.
+5. Initialize ESP-NOW, GPS UART, and the BNO08x IMU.
+6. Start state-estimation, position-control, hover-control, servo-actuation,
+   DShot motor, telemetry, and barometer tasks.
+7. Arm both ESCs together with five seconds of zero-throttle DShot frames. The
+   vehicle remains software-ESTOP'd until a valid ground-station ARM command.
+
+ARM is accepted only when the stored ground-station throttle is zero. A valid
+ARM command then:
+
+- moves the barometric zero to the latest valid reading;
+- captures the current IMU roll, pitch, and yaw as the attitude reference;
+- clears shared position, velocity, position-controller, and hover-controller
+  outputs;
+- requests a coordinated reset of the Kalman state and controller integrators;
+  and
+- clears ESTOP, enabling the servo outputs and manual motor throttle.
+
+`ZERO_IMU` performs the same reference capture and coordinated reset, but it is
+accepted only while ESTOP is active. This prevents the control reference from
+changing during flight.
+
+ESTOP immediately stores zero motor power. The motor task continuously sends
+zero DShot while ESTOP is active, and the servo task removes PWM from both TVC
+channels. Loss of ground-station traffic for 500 ms also latches ESTOP. ARM is
+rejected if a nonzero throttle value is stored.
+
+## Default tethered attitude-control mode
+
+With `MANUAL_THROTTLE_ATTITUDE_ONLY_MODE=1` and the two test modes disabled:
+
+- ground-station power is converted to the same DShot throttle for both motors;
+- the 50 Hz inner LQR uses IMU attitude and angular-rate errors relative to the
+  attitude captured at ARM;
+- the LQR force/moment output passes through the controls team's existing
+  force-to-gimbal inverse mapping;
+- the resulting gimbal deflections are clamped, converted through the physical
+  midpoint/direction calibration, and sent by the independent actuator task;
+- altitude, vertical velocity, and altitude-integral errors are forced to zero;
+- calculated controller motor speeds are forced to zero and are not passed to
+  DShot or the Kalman process model; and
+- horizontal-position gains remain zero, and `U_pos` is explicitly excluded
+  from the attitude reference. This also prevents a failed position estimate
+  from contaminating attitude control through IEEE-754 `0 * NaN` propagation.
+
+This mode is manual-throttle attitude stabilization. It does not automatically
+hold altitude or position, and it does not convert the controller's requested
+motor angular velocity into DShot commands.
+
+## Hardware test modes
+
+Only one isolated test mode should be enabled at a time.
+
+### Direct IMU-to-gimbal direction test
+
+Set `GIMBAL_ATTITUDE_MAPPING_TEST_MODE=1` and keep
+`MOTOR_WIRING_TEST_MODE=0`. This mode retains normal sensors, ARM, ESTOP, and
+communications, but bypasses the LQR magnitude and inverse mapping:
+
+- ARM captures the neutral attitude.
+- Measured roll displacement maps 1:1 to gimbal 1.
+- Measured pitch displacement maps 1:1 to gimbal 2.
+- Yaw displacement is logged but does not map to a gimbal axis.
+- Both ESCs are locked to zero DShot; nonzero `SET_POWER` commands are ignored.
+- Existing servo midpoints, inversion, and +/-13-degree limits remain active.
+
+Expected examples after ARM are:
+
+| Attitude displacement | Controller command | PCA9685 command |
+| --- | --- | --- |
+| Roll +8 degrees | Gimbal 1 +8 degrees | Channel 0 = 102 degrees |
+| Roll -8 degrees | Gimbal 1 -8 degrees | Channel 0 = 118 degrees |
+| Pitch +8 degrees | Gimbal 2 +8 degrees | Channel 7 = 72 degrees |
+| Pitch -8 degrees | Gimbal 2 -8 degrees | Channel 7 = 88 degrees |
+
+This mode verifies the complete IMU-axis, gimbal-channel, electrical-direction,
+and linkage-direction convention without thrust or fast LQR saturation.
+
+### Combined motor and servo wiring test
+
+Set `MOTOR_WIRING_TEST_MODE=1`. This isolated test bypasses IMU, GPS, ESP-NOW,
+BMP390, and all flight-control tasks. It:
+
+1. centres channel 0 at 110 degrees and channel 7 at 80 degrees;
+2. waits one second for the gimbal to settle;
+3. arms both ESCs together at zero for five seconds;
+4. commands both motors to a fixed 5% DShot throttle;
+5. sweeps gimbal 1 by +/-10 degrees with a seven-second period; and
+6. sweeps gimbal 2 by +/-10 degrees with a ten-second period.
+
+The different periods produce a repeating 70-second set of gimbal-position
+combinations. A DShot or servo-output error commands motor zero and disables the
+servos. This mode intentionally bypasses the normal heartbeat and software
+ESTOP path, so use it only with the vehicle restrained and the propeller area
+clear; terminate it by resetting or removing power.
+
+### Serial servo calibration test
+
+Set `SERVO_TERMINAL_TEST_MODE=1` for an isolated PCA9685 test. Motors, sensors,
+GPS, ESP-NOW, and flight-control tasks remain disabled. All 16 PCA9685 channels
+are turned off at startup, then the terminal accepts an absolute angle from
+0-180 degrees for `SERVO_TERMINAL_TEST_CHANNEL`; enter `off` to remove its PWM.
+
+## Logging and diagnostics
+
+- State and IMU summaries are rate-limited to approximately 2 Hz.
+- Attitude-control logs show roll/pitch/yaw error, zero-centred gimbal commands,
+  final absolute channel 0/channel 7 angles, and manual throttle.
+- The direct mapping mode logs attitude displacement and confirms motors are
+  locked at 0%.
+- The ESP-NOW callback no longer prints a TX line for every 100 Hz telemetry
+  packet; periodic aggregate success statistics remain available.
+
+## Known limitations before free flight
+
+- The current force-to-gimbal calculation uses `acos` for gimbal 2, which does
+  not encode a signed angle. The controls team still needs to validate and
+  correct this inverse mapping around the hover operating point.
+- DShot percentage has not been calibrated against measured motor angular
+  velocity or thrust. The provisional simulation convention is 100% = 25
+  rad/s (approximately 239 RPM), but the firmware does not currently use this
+  as a physical DShot conversion and the real relationship is not assumed to
+  be linear.
+- Setting `MANUAL_THROTTLE_ATTITUDE_ONLY_MODE=0` does not by itself enable
+  autonomous thrust or altitude control. An explicit omega-to-DShot/thrust
+  mapping and motor actuation integration are still required.
+- The legacy ESP-IDF I2C API still builds under ESP-IDF 6 but is scheduled for
+  removal in ESP-IDF 7 and should be migrated separately.
 
 ## Hardware validation status
 
-On 2026-08-08, the merged ESP-IDF 6 firmware was built, flashed, and exercised
-on the drone hardware. The full normal startup path behaved as expected,
-including the sensor stack, communications, simultaneous ESC initialization,
-DShot motor control, and startup/ESTOP safety behavior.
+On 2026-08-08, the ESP-IDF 6 firmware was built, flashed, and exercised on the
+drone hardware. The following were confirmed:
 
-Still to test: closed-loop servo actuation and the connection from the control
-system outputs to PCA9685 channels 0 and 7. That integration is being
-implemented separately; the current position and hover controllers calculate
-outputs but do not yet command the physical servos.
+- I2C/PCA9685, BMP390, BNO08x, ESP-NOW, and DShot startup;
+- simultaneous ESC initialization and ground-station motor control;
+- ARM, ESTOP, link-loss failsafe, and zero-throttle arming checks;
+- servo channels 0 and 7, physical midpoints 110/80 degrees, and mechanical
+  travel around both midpoints;
+- both servo outputs require inversion relative to controller-positive gimbal
+  commands; and
+- the zero-thrust 1:1 attitude mapping moves both gimbals in the intended
+  corrective physical direction.
+
+The current source also builds successfully with ESP-IDF 6.0.2. Still to test
+is the powered short-tether response of the complete LQR and force-to-gimbal
+inverse mapping. Do not treat the successful static direction test as proof of
+closed-loop stability.
 
 ## Problems encountered and fixes
 

--- a/lander/main/comms/comm.cpp
+++ b/lander/main/comms/comm.cpp
@@ -158,10 +158,10 @@ static void send_cb(const wifi_tx_info_t* tx_info, esp_now_send_status_t status)
     if (s_send_cb) {
         s_send_cb(mac_addr, status);
     }
-    ESP_LOGI(TAG, "TX status: %d to %02x:%02x:%02x:%02x:%02x:%02x",
-             (int)status,
-             mac_addr[0], mac_addr[1], mac_addr[2],
-             mac_addr[3], mac_addr[4], mac_addr[5]);
+
+    // This callback runs for every telemetry packet (currently 100 Hz).
+    // Per-packet logging overwhelms the terminal, so status is recorded by
+    // the registered callback and reported through its periodic statistics.
 }
 
 // ---------------------------------------------------------------------------

--- a/lander/main/espnow_init.cpp
+++ b/lander/main/espnow_init.cpp
@@ -7,6 +7,7 @@
 #include "globalvars.hpp"
 #include "comms/comm.h"
 #include "motor_init.hpp"
+#include "i2c/bmp390.hpp"
 #include <cstring>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -21,6 +22,21 @@ static uint8_t receiver_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}; //Broadcas
 static std::atomic<bool> send_pending(false);
 static std::atomic<uint32_t> send_success_count(0);
 static std::atomic<uint32_t> send_fail_count(0);
+
+static bool reset_flight_reference(const char *reason) {
+    esp_err_t baro_result = bmp390_zero_altitude_at_current_position();
+    if (baro_result != ESP_OK) {
+        ESP_LOGE(TAG, "%s rejected: barometer zero unavailable (%s)",
+                 reason, esp_err_to_name(baro_result));
+        return false;
+    }
+
+    const uint32_t generation = capture_flight_reference_and_request_reset();
+    ESP_LOGW(TAG,
+             "%s: captured current attitude/altitude reference and requested flight-state reset #%lu",
+             reason, static_cast<unsigned long>(generation));
+    return true;
+}
 
 //callback function for send status
 void on_data_sent(const uint8_t* mac_addr, esp_now_send_status_t status) {
@@ -45,22 +61,29 @@ void esp_now_cmd_handler(const uint8_t *data, size_t len, const uint8_t *src_mac
                 ESP_LOGE(TAG,
                          "ARM rejected: commanded power must be zero (currently %u%%)",
                          motor_power_percent.load());
-            } else {
+            } else if (reset_flight_reference("ARM")) {
                 ESP_LOGW(TAG, "ARM COMMAND RECEIVED at zero power!");
                 estop_triggered = false;
             }
         } else if (cmd->command == 2) { //ZERO_IMU
-            ESP_LOGW(TAG, "ZERO IMU COMMAND RECEIVED!");
-            portENTER_CRITICAL(&global_spinlock);
-            latest_velocity = {0.0, 0.0, 0.0};
-            latest_position = {0.0, 0.0, 0.0};
-            portEXIT_CRITICAL(&global_spinlock);
+            if (!estop_triggered.load()) {
+                ESP_LOGE(TAG, "ZERO_IMU rejected while armed; ESTOP first");
+            } else {
+                reset_flight_reference("ZERO_IMU");
+            }
         } else if (cmd->command == 5) { //SET_PIN
             ESP_LOGW(TAG, "SET_PIN COMMAND RECEIVED! Motor %d -> GPIO %d", cmd->arg1, cmd->arg2);
             request_motor_pin_change(cmd->arg1, (gpio_num_t)cmd->arg2);
         } else if (cmd->command == 6) { //SET_POWER
+#if GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+            motor_power_percent = 0;
+            ESP_LOGW(TAG,
+                     "SET_POWER %d%% ignored: gimbal attitude mapping test locks both motors at 0%%",
+                     cmd->arg1);
+#else
             ESP_LOGW(TAG, "SET_POWER COMMAND RECEIVED! Power -> %d%%", cmd->arg1);
             motor_power_percent = cmd->arg1;
+#endif
         }
     }
 }

--- a/lander/main/globalvars.cpp
+++ b/lander/main/globalvars.cpp
@@ -1,10 +1,27 @@
 // globalvars.cpp
 #include "globalvars.hpp"
+#include <cmath>
 
 // Initialize global variables
 portMUX_TYPE global_spinlock = portMUX_INITIALIZER_UNLOCKED;
 
 double target_velocity_multiplier = 1.0; // Default value, can be adjusted as needed
+
+// Physical TVC servo calibration. The PCA9685 servo API consumes degrees,
+// while U_hov.alpha1/alpha2 remain zero-centred gimbal deflections in radians.
+const float servo_midpoint_1_deg = 110.0f;
+const float servo_midpoint_2_deg = 80.0f;
+
+// Convert controller-positive gimbal deflections into each servo's electrical
+// direction. Both installed servos require inversion around their midpoints.
+const float servo_direction_1 = -1.0f;
+const float servo_direction_2 = -1.0f;
+
+// Conservative initial travel limits around the mechanical midpoints. Servo 1
+// was measured at +/-13 degrees; verify servo 2 and both linkage directions on
+// hardware before increasing either limit.
+const float servo_max_deflection_1_deg = 13.0f;
+const float servo_max_deflection_2_deg = 13.0f;
 
 bno08x_euler_angle_t latest_euler_data;
 bno08x_gyro_t latest_ang_velocity_data;
@@ -17,6 +34,8 @@ latest_lin_velocity_t latest_velocity = {0.0, 0.0, 0.0}; // Initialize velocity 
 gps_position_t latest_gps_position = {0.0, 0.0, 0.0};
 u_pos_t U_pos = {0.0f, 0.0f};
 u_hov_t U_hov = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+attitude_reference_t attitude_reference = {0.0f, 0.0f, 0.0f};
+std::atomic<uint32_t> flight_state_reset_generation{0};
 int64_t latest_timestamp = 0; // Initialize timestamp to 0
 int32_t euler_counter = 0; // Initialize counter to 0
 double temperature;
@@ -30,3 +49,24 @@ std::atomic<int64_t> last_gs_msg_time{0};
 // Power always starts at zero. Arming must never reuse a nonzero value left
 // over from a previous ground-station session.
 std::atomic<uint8_t> motor_power_percent{0};
+
+uint32_t capture_flight_reference_and_request_reset()
+{
+    constexpr float DEG_TO_RAD = static_cast<float>(M_PI) / 180.0f;
+
+    portENTER_CRITICAL(&global_spinlock);
+    attitude_reference.roll = latest_euler_data.x * DEG_TO_RAD;
+    attitude_reference.pitch = latest_euler_data.y * DEG_TO_RAD;
+    attitude_reference.yaw = latest_euler_data.z * DEG_TO_RAD;
+    latest_position = {0.0, 0.0, 0.0};
+    latest_velocity = {0.0, 0.0, 0.0};
+    altitude = 0.0;
+    U_pos = {0.0f, 0.0f};
+    U_hov = {0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+    portEXIT_CRITICAL(&global_spinlock);
+
+    // Increment only after the shared reset values have been published. Each
+    // control/estimation task observes this generation and clears its private
+    // state before calculating another output.
+    return flight_state_reset_generation.fetch_add(1) + 1;
+}

--- a/lander/main/globalvars.hpp
+++ b/lander/main/globalvars.hpp
@@ -2,12 +2,22 @@
 #define GLOBALVARS_HPP
 
 #include <atomic>
+#include <cstdint>
 #include "esp_log.h"
 #include <vector>
 #include <BNO08xGlobalTypes.hpp>
 #include <freertos/FreeRTOS.h>
 
 // Global variables
+// Physical TVC servo calibration in degrees. Controller gimbal outputs remain
+// zero-centred radians and are converted only by the servo actuator task.
+extern const float servo_midpoint_1_deg;
+extern const float servo_midpoint_2_deg;
+extern const float servo_direction_1;
+extern const float servo_direction_2;
+extern const float servo_max_deflection_1_deg;
+extern const float servo_max_deflection_2_deg;
+
 extern portMUX_TYPE global_spinlock;
 extern bno08x_euler_angle_t latest_euler_data;
 extern bno08x_gyro_t latest_ang_velocity_data;
@@ -63,6 +73,18 @@ typedef struct {
 } u_hov_t;
 
 extern u_hov_t U_hov;
+
+// Attitude held by the attitude-only controller. A ZERO_IMU command or a
+// successful ARM captures the current IMU orientation as the zero-error pose.
+typedef struct {
+    float roll;
+    float pitch;
+    float yaw;
+} attitude_reference_t;
+
+extern attitude_reference_t attitude_reference;
+extern std::atomic<uint32_t> flight_state_reset_generation;
+uint32_t capture_flight_reference_and_request_reset();
 
 extern std::atomic<bool> estop_triggered;
 extern std::atomic<bool> servo_testing_mode;

--- a/lander/main/i2c/bmp390.cpp
+++ b/lander/main/i2c/bmp390.cpp
@@ -35,6 +35,10 @@ static const char *TAG = "BMP390";
 // Structure to hold calibration data
 static bmp390_calib_data_t calib_data;
 static bool bmp390_initialized = false;
+static portMUX_TYPE altitude_reference_lock = portMUX_INITIALIZER_UNLOCKED;
+static double altitude_zero_m = 0.0;
+static double last_absolute_altitude_m = 0.0;
+static bool altitude_zero_valid = false;
 
 // Helper function to write a single byte to a register
 static esp_err_t bmp390_write8(uint8_t reg, uint8_t data) {
@@ -239,8 +243,9 @@ double calculateAltitude(double pressure, double temperatureCelsius) {
     return CONST * temperatureKelvin * logf(SEA_LEVEL_PRESSURE / pressure);
 }
 
-// Read compensated temperature and pressure data
-esp_err_t bmp390_get_data(double *temperature, double *pressure, double *altitude) {
+// Read compensated temperature, pressure, and absolute barometric altitude.
+static esp_err_t bmp390_get_absolute_data(double *temperature, double *pressure,
+                                          double *absolute_altitude) {
     if (!bmp390_initialized) {
         ESP_LOGE(TAG, "BMP390 not initialized.");
         return ESP_ERR_INVALID_STATE;
@@ -263,7 +268,79 @@ esp_err_t bmp390_get_data(double *temperature, double *pressure, double *altitud
     // Compensate raw values
     *temperature = bmp390_compensate_temp(raw_temp);
     *pressure = bmp390_compensate_press(raw_press);
-    *altitude = calculateAltitude(*pressure, *temperature); // Calculate altitude
+    *absolute_altitude = calculateAltitude(*pressure, *temperature);
 
+    return ESP_OK;
+}
+
+esp_err_t bmp390_calibrate_altitude_zero(uint16_t sample_count,
+                                         uint32_t sample_interval_ms) {
+    if (sample_count == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    double altitude_sum = 0.0;
+    double last_altitude = 0.0;
+    for (uint16_t sample = 0; sample < sample_count; ++sample) {
+        double temperature = 0.0;
+        double pressure = 0.0;
+        esp_err_t result = bmp390_get_absolute_data(
+            &temperature, &pressure, &last_altitude);
+        if (result != ESP_OK) {
+            ESP_LOGE(TAG, "Altitude-zero calibration failed at sample %u/%u: %s",
+                     sample + 1, sample_count, esp_err_to_name(result));
+            return result;
+        }
+        altitude_sum += last_altitude;
+        if (sample + 1 < sample_count) {
+            vTaskDelay(pdMS_TO_TICKS(sample_interval_ms));
+        }
+    }
+
+    const double calibrated_zero = altitude_sum / sample_count;
+    portENTER_CRITICAL(&altitude_reference_lock);
+    altitude_zero_m = calibrated_zero;
+    last_absolute_altitude_m = last_altitude;
+    altitude_zero_valid = true;
+    portEXIT_CRITICAL(&altitude_reference_lock);
+
+    ESP_LOGI(TAG,
+             "Altitude zero calibrated from %u samples (absolute reference %.2f m)",
+             sample_count, calibrated_zero);
+    return ESP_OK;
+}
+
+esp_err_t bmp390_zero_altitude_at_current_position() {
+    portENTER_CRITICAL(&altitude_reference_lock);
+    if (!altitude_zero_valid) {
+        portEXIT_CRITICAL(&altitude_reference_lock);
+        return ESP_ERR_INVALID_STATE;
+    }
+    altitude_zero_m = last_absolute_altitude_m;
+    portEXIT_CRITICAL(&altitude_reference_lock);
+    return ESP_OK;
+}
+
+// Read compensated data and report altitude relative to the calibrated launch
+// reference rather than the fixed standard-atmosphere datum.
+esp_err_t bmp390_get_data(double *temperature, double *pressure, double *altitude) {
+    double absolute_altitude = 0.0;
+    esp_err_t result = bmp390_get_absolute_data(
+        temperature, pressure, &absolute_altitude);
+    if (result != ESP_OK) {
+        return result;
+    }
+
+    portENTER_CRITICAL(&altitude_reference_lock);
+    if (!altitude_zero_valid) {
+        portEXIT_CRITICAL(&altitude_reference_lock);
+        ESP_LOGE(TAG, "Altitude requested before zero calibration");
+        return ESP_ERR_INVALID_STATE;
+    }
+    last_absolute_altitude_m = absolute_altitude;
+    const double zero = altitude_zero_m;
+    portEXIT_CRITICAL(&altitude_reference_lock);
+
+    *altitude = absolute_altitude - zero;
     return ESP_OK;
 }

--- a/lander/main/i2c/bmp390.hpp
+++ b/lander/main/i2c/bmp390.hpp
@@ -54,6 +54,14 @@ typedef struct {
  */
 esp_err_t bmp390_init();
 
+// Average several stationary readings and define that altitude as zero.
+esp_err_t bmp390_calibrate_altitude_zero(uint16_t sample_count,
+                                         uint32_t sample_interval_ms);
+
+// Move the zero reference to the most recent valid barometer reading. This is
+// non-blocking and is used by ZERO_IMU and immediately before ARM.
+esp_err_t bmp390_zero_altitude_at_current_position();
+
 /**
  * @brief Read compensated temperature and pressure data from the BMP390.
  *

--- a/lander/main/i2c/servo.cpp
+++ b/lander/main/i2c/servo.cpp
@@ -1,9 +1,12 @@
+#include "servo.hpp"
 #include "driver/i2c.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
 #include "../config.hpp"
+#include "../globalvars.hpp"
+#include <cmath>
  
 static const char *TAG = "PCA9685";
  
@@ -132,6 +135,12 @@ esp_err_t pca9685_set_channel_off(uint8_t servo_num) {
  * @return esp_err_t ESP_OK on success, otherwise an error code.
  */
 esp_err_t pca9685_set_servo_angle(uint8_t servo_num, float angle) {
+    if (!std::isfinite(angle) || angle < 0.0f || angle > 180.0f) {
+        ESP_LOGE(TAG, "Invalid angle for servo %u: %.2f degrees",
+                 servo_num, angle);
+        return ESP_ERR_INVALID_ARG;
+    }
+
     // Tested empirically:
     // Start point is between 110-120
     // End point is between 540-550
@@ -146,6 +155,103 @@ esp_err_t pca9685_set_servo_angle(uint8_t servo_num, float angle) {
 
     // Set the PWM value for the servo
     return pca9685_set_pwm(servo_num, 0, pwm_value);
+}
+
+static float clamp_float(float value, float minimum, float maximum) {
+    if (value < minimum) return minimum;
+    if (value > maximum) return maximum;
+    return value;
+}
+
+esp_err_t tvc_servos_set_deflection_rad(float alpha1_rad, float alpha2_rad) {
+    if (!std::isfinite(alpha1_rad) || !std::isfinite(alpha2_rad)) {
+        ESP_LOGE(TAG, "Rejecting non-finite TVC command (alpha1=%.4f, alpha2=%.4f)",
+                 alpha1_rad, alpha2_rad);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    constexpr float RAD_TO_DEG = 180.0f / static_cast<float>(M_PI);
+
+    const float alpha1_deg = clamp_float(
+        alpha1_rad * RAD_TO_DEG,
+        -servo_max_deflection_1_deg,
+        servo_max_deflection_1_deg);
+    const float alpha2_deg = clamp_float(
+        alpha2_rad * RAD_TO_DEG,
+        -servo_max_deflection_2_deg,
+        servo_max_deflection_2_deg);
+
+    const float servo1_command_deg = clamp_float(
+        servo_midpoint_1_deg + servo_direction_1 * alpha1_deg, 0.0f, 180.0f);
+    const float servo2_command_deg = clamp_float(
+        servo_midpoint_2_deg + servo_direction_2 * alpha2_deg, 0.0f, 180.0f);
+
+    esp_err_t result = pca9685_set_servo_angle(
+        TVC_SERVO_1_CHANNEL, servo1_command_deg);
+    if (result != ESP_OK) return result;
+
+    return pca9685_set_servo_angle(
+        TVC_SERVO_2_CHANNEL, servo2_command_deg);
+}
+
+esp_err_t tvc_servo_outputs_disable() {
+    const esp_err_t result1 = pca9685_set_channel_off(TVC_SERVO_1_CHANNEL);
+    const esp_err_t result2 = pca9685_set_channel_off(TVC_SERVO_2_CHANNEL);
+    if (result1 != ESP_OK || result2 != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to disable TVC servo outputs (servo1: %s, servo2: %s)",
+                 esp_err_to_name(result1), esp_err_to_name(result2));
+        return result1 != ESP_OK ? result1 : result2;
+    }
+    return ESP_OK;
+}
+
+void tvc_servo_actuation_task(void *pvParameters) {
+    constexpr TickType_t UPDATE_INTERVAL = pdMS_TO_TICKS(20); // 50 Hz
+    bool outputs_disabled = false;
+
+    ESP_LOGI(TAG,
+             "TVC servo task ready: channel %d midpoint %.1f deg, channel %d midpoint %.1f deg",
+             TVC_SERVO_1_CHANNEL, servo_midpoint_1_deg,
+             TVC_SERVO_2_CHANNEL, servo_midpoint_2_deg);
+
+    while (true) {
+        if (estop_triggered.load()) {
+            if (!outputs_disabled) {
+                if (tvc_servo_outputs_disable() == ESP_OK) {
+                    outputs_disabled = true;
+                    ESP_LOGI(TAG, "TVC servo outputs disabled by ESTOP");
+                }
+            }
+            vTaskDelay(UPDATE_INTERVAL);
+            continue;
+        }
+
+        float alpha1_rad;
+        float alpha2_rad;
+        portENTER_CRITICAL(&global_spinlock);
+        alpha1_rad = U_hov.alpha1;
+        alpha2_rad = U_hov.alpha2;
+        portEXIT_CRITICAL(&global_spinlock);
+
+        const esp_err_t result =
+            tvc_servos_set_deflection_rad(alpha1_rad, alpha2_rad);
+        if (result != ESP_OK) {
+            ESP_LOGE(TAG, "TVC servo command failed: %s; latching ESTOP",
+                     esp_err_to_name(result));
+            motor_power_percent = 0;
+            estop_triggered = true;
+            outputs_disabled = (tvc_servo_outputs_disable() == ESP_OK);
+            vTaskDelay(UPDATE_INTERVAL);
+            continue;
+        }
+
+        if (outputs_disabled) {
+            ESP_LOGI(TAG, "TVC servo actuation enabled");
+            outputs_disabled = false;
+        }
+
+        vTaskDelay(UPDATE_INTERVAL);
+    }
 }
 
 esp_err_t pca9685_init(){

--- a/lander/main/i2c/servo.hpp
+++ b/lander/main/i2c/servo.hpp
@@ -27,5 +27,8 @@ esp_err_t pca9685_write8(uint8_t reg, uint8_t data);
 esp_err_t pca9685_read8(uint8_t reg, uint8_t *data);
 esp_err_t pca9685_set_pwm(uint8_t servo_num, uint16_t on, uint16_t off);
 esp_err_t pca9685_set_channel_off(uint8_t servo_num);
+esp_err_t tvc_servos_set_deflection_rad(float alpha1_rad, float alpha2_rad);
+esp_err_t tvc_servo_outputs_disable();
+void tvc_servo_actuation_task(void *pvParameters);
 
 #endif // LANDER_SERVO

--- a/lander/main/main.cpp
+++ b/lander/main/main.cpp
@@ -90,7 +90,7 @@ void measure_datarate(void *pvParameters)
         //todo: error not handled when vector size is 0
         //ESP_LOGI(TAG, "Last Euler Angle: (x (roll): %.2f y (pitch): %.2f z (yaw): %.2f)[deg]", euler_data.back().x, euler_data.back().y, euler_data.back().z);
         //ESP_LOGI(TAG, "Linear Accel: (x: %.2f y: %.2f z: %.2f)[m/s^2]", lin_accel_data.back().x, lin_accel_data.back().y, lin_accel_data.back().z);
-        vTaskDelay(pdMS_TO_TICKS(50)); // Delay for 500ms
+        vTaskDelay(pdMS_TO_TICKS(500));
     }
 }
 
@@ -212,9 +212,19 @@ void state_estimation(void *pvParameters)
 
     // GPS freshness tracking
     static float last_gps[3] = {0.0f, 0.0f, 0.0f};
+    uint32_t handled_reset_generation = flight_state_reset_generation.load();
 
     while (1)
     {
+        const uint32_t requested_reset = flight_state_reset_generation.load();
+        if (requested_reset != handled_reset_generation) {
+            memset(X, 0, sizeof(X));
+            memset(last_gps, 0, sizeof(last_gps));
+            handled_reset_generation = requested_reset;
+            ESP_LOGI(TAG, "State estimator reset #%lu applied",
+                     static_cast<unsigned long>(requested_reset));
+        }
+
         // -----------------------------------------------------------------
         // 1. Read sensor data under spinlock
         // -----------------------------------------------------------------
@@ -243,16 +253,20 @@ void state_estimation(void *pvParameters)
         }
 
         // -----------------------------------------------------------------
-        // 3. Build control input U = [a1, a2, wt1, wt2]
-        //    Fly-test: K_hov = 0, so U_hov.omega = 0 while motors run from
-        //    motor_power_percent (GS slider). Revisit when hover control is on.
+        // 3. Build control input U = [a1, a2, wt1, wt2]. In the first tethered
+        //    attitude-only mode the gimbal commands are real actuator inputs,
+        //    but no calibrated DShot-percent-to-motor-speed mapping exists.
+        //    Keep wt1/wt2 at zero rather than injecting the controller's
+        //    unapplied omega requests into the process model.
         // -----------------------------------------------------------------
         float U[4] = {0.0f, 0.0f, 0.0f, 0.0f};
         portENTER_CRITICAL(&global_spinlock);
         U[0] = U_hov.alpha1;  // gimbal1 angle [rad]
         U[1] = U_hov.alpha2;  // gimbal2 angle [rad]
+#if !MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
         U[2] = U_hov.omega1;  // motor1 speed  [rad/s]
         U[3] = U_hov.omega2;  // motor2 speed  [rad/s]
+#endif
         portEXIT_CRITICAL(&global_spinlock);
 
         // -----------------------------------------------------------------
@@ -409,9 +423,23 @@ void position_controller(void *pvParameters)
     // Integral accumulators (persist across iterations)
     static float error_integral_x = 0.0f;
     static float error_integral_y = 0.0f;
+    uint32_t handled_reset_generation = flight_state_reset_generation.load();
 
     while (1)
     {
+        const uint32_t requested_reset = flight_state_reset_generation.load();
+        if (estop_triggered.load()
+            || requested_reset != handled_reset_generation) {
+            error_integral_x = 0.0f;
+            error_integral_y = 0.0f;
+            portENTER_CRITICAL(&global_spinlock);
+            U_pos = {0.0f, 0.0f};
+            portEXIT_CRITICAL(&global_spinlock);
+            handled_reset_generation = requested_reset;
+            vTaskDelay(pdMS_TO_TICKS(PERIOD_MS));
+            continue;
+        }
+
         // -----------------------------------------------------------------
         // 1. Read Kalman filter outputs under spinlock
         // -----------------------------------------------------------------
@@ -503,36 +531,65 @@ void position_controller(void *pvParameters)
 void hover_controller(void *pvParameters)
 {
     constexpr uint32_t PERIOD_MS             = 20;      // 50 Hz
+#if !MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
     constexpr float    CONTROL_LOOP_INTERVAL = 0.02f;   // [s]
+#endif
 
     constexpr float deg2rad = static_cast<float>(M_PI / 180.0);
 
-    // Actuation mapping constants
+    // Actuation mapping constants used by the normal hover controller. The
+    // temporary 1:1 gimbal mapping test bypasses this force conversion.
+#if !GIMBAL_ATTITUDE_MAPPING_TEST_MODE
     constexpr float KT_ACT = 0.021f;  // thrust coefficient [N/(rad/s)²]
     constexpr float C_ARM  = 0.1f;    // gimbal moment arm [m] — matches KF ARM / David's Simulink a = 0.1
+#endif
 
-    // Anti-windup throttle threshold — PLACEHOLDER: fill in before use
+    // Anti-windup throttle threshold — PLACEHOLDER for the future
+    // closed-loop altitude/thrust mode.
+#if !MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
     constexpr float MAX_THROTTLE   = 0.0f;  // maximum throttle value
     constexpr float DSHOT_THROTTLE = 0.0f;  // current throttle PLACEHOLDER
+#endif
 
     // K_hov (4×9) — LQR gain matrix, row-major
     // lqr_out = K_hov * [roll_err, pitch_err, yaw_err, gx_err, gy_err, gz_err, z_err, vz_err, int_z_err]'
-    // Fly-test: gains intentionally zero — throttle is manual via the ground-
-    // station slider. Fill in tuned LQR values before closed-loop hover.
-    static const float K_hov[4 * 9] = {0.0000, 0.0000, -0.0000, -17.3205, -0.0000, 0.0000, -6.6814, -0.0000, 0.0000， 
-                                       0.0000, 0.0000, 17.3205, -0.0000, 0.0000, 6.6814, -0.0000, 0.0000, 0.0000， 
-                                       11.0254, 5.2077, -0.0000, 0.0000, 0.6235, -0.0000, 0.0000, 1.9492, 6.9881，
-                                       -0.0262, -0.0117, 0.0000, 0.0000, 0.0625, -0.0000, -0.0000, 0.1946, -0.0167};
+    // Tuned hover gains. Each row produces one of [F1, F2, F3, Mz].
+#if !GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+    static const float K_hov[4 * 9] = {
+         0.0000f,  0.0000f, -0.0000f, -17.3205f, -0.0000f,  0.0000f, -6.6814f, -0.0000f,  0.0000f,
+         0.0000f,  0.0000f, 17.3205f,  -0.0000f,  0.0000f,  6.6814f, -0.0000f,  0.0000f,  0.0000f,
+        11.0254f,  5.2077f, -0.0000f,   0.0000f,  0.6235f, -0.0000f,  0.0000f,  1.9492f,  6.9881f,
+        -0.0262f, -0.0117f,  0.0000f,   0.0000f,  0.0625f, -0.0000f, -0.0000f,  0.1946f, -0.0167f,
+    };
+#endif
 
     // SP_hover (9×1) — hover setpoint; all zeros (level attitude, hold position)
     // SP_hover[0] and [1] are augmented by U_pos each iteration.
     static const float SP_hover[9] = {0};
 
-    // Altitude integral accumulator
+    // Altitude integral accumulator for the future closed-loop thrust mode.
+#if !MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
     static float error_integral_z = 0.0f;
+#endif
+    uint32_t handled_reset_generation = flight_state_reset_generation.load();
+    int64_t last_control_log_us = 0;
 
     while (1)
     {
+        const uint32_t requested_reset = flight_state_reset_generation.load();
+        if (estop_triggered.load()
+            || requested_reset != handled_reset_generation) {
+#if !MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
+            error_integral_z = 0.0f;
+#endif
+            portENTER_CRITICAL(&global_spinlock);
+            U_hov = {0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+            portEXIT_CRITICAL(&global_spinlock);
+            handled_reset_generation = requested_reset;
+            vTaskDelay(pdMS_TO_TICKS(PERIOD_MS));
+            continue;
+        }
+
         // -----------------------------------------------------------------
         // 1. Read sensor data under spinlock
         // -----------------------------------------------------------------
@@ -545,8 +602,11 @@ void hover_controller(void *pvParameters)
         float gz    = static_cast<float>(latest_ang_velocity_data.z);
         float z     = static_cast<float>(latest_position.z);
         float vz    = static_cast<float>(latest_velocity.z);
+#if !GIMBAL_ATTITUDE_MAPPING_TEST_MODE && !MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
         float upos_roll  = U_pos.roll;
         float upos_pitch = U_pos.pitch;
+#endif
+        attitude_reference_t reference = attitude_reference;
         portEXIT_CRITICAL(&global_spinlock);
 
         // -----------------------------------------------------------------
@@ -554,8 +614,18 @@ void hover_controller(void *pvParameters)
         // -----------------------------------------------------------------
         float ref[9];
         for (int i = 0; i < 9; i++) ref[i] = SP_hover[i];
-        ref[0] += upos_roll;   // desired roll  [rad]
-        ref[1] += upos_pitch;  // desired pitch [rad]
+#if GIMBAL_ATTITUDE_MAPPING_TEST_MODE || MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
+        // The mapping test and first tethered-flight mode both deliberately
+        // exclude horizontal-position commands. K_pos remains zero, and this
+        // explicit bypass also prevents a failed estimator's NaN from leaking
+        // through IEEE-754 zero-matrix multiplication into the attitude loop.
+        ref[0] += reference.roll;                 // desired roll  [rad]
+        ref[1] += reference.pitch;                // desired pitch [rad]
+#else
+        ref[0] += reference.roll + upos_roll;     // desired roll  [rad]
+        ref[1] += reference.pitch + upos_pitch;   // desired pitch [rad]
+#endif
+        ref[2] += reference.yaw;                  // desired yaw   [rad]
 
         // -----------------------------------------------------------------
         // 3. Build state and compute error = ref - X
@@ -567,16 +637,43 @@ void hover_controller(void *pvParameters)
         // Wrap yaw error
         if (error[2] > static_cast<float>(M_PI))
             error[2] -= 2.0f * static_cast<float>(M_PI);
+        else if (error[2] < -static_cast<float>(M_PI))
+            error[2] += 2.0f * static_cast<float>(M_PI);
 
         // -----------------------------------------------------------------
-        // 4. Altitude integral with anti-windup
+        // 4. Altitude integral with anti-windup. The first tethered-flight
+        //    mode is manual-throttle/attitude-only, so altitude states are
+        //    deliberately removed from the actuator command.
         // -----------------------------------------------------------------
+#if MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
+        error[6] = 0.0f;
+        error[7] = 0.0f;
+        error[8] = 0.0f;
+#else
         float error_z = error[6];
         if (DSHOT_THROTTLE < MAX_THROTTLE || error_z < 0.0f) {
             error_integral_z += error_z * CONTROL_LOOP_INTERVAL;
         }
         error[8] = error_integral_z;
+#endif
 
+        float alpha_1 = 0.0f;
+        float alpha_2 = 0.0f;
+        float omega_1 = 0.0f;
+        float omega_2 = 0.0f;
+        float lambda  = 1.0f;
+
+#if GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+        // Exact 1:1 direction test using the small-angle vehicle model:
+        //   +alpha1 creates -roll acceleration
+        //   +alpha2 creates -pitch acceleration
+        // Therefore a positive displacement from the captured attitude needs
+        // an equal positive gimbal angle to create a restoring acceleration.
+        // Yaw is observable in the log but is not controllable by either of
+        // the two gimbal axes; normal flight uses differential motor torque.
+        alpha_1 = -error[0]; // measured roll  - captured roll
+        alpha_2 = -error[1]; // measured pitch - captured pitch
+#else
         // -----------------------------------------------------------------
         // 5. LQR: lqr_out (4×1) = K_hov (4×9) * error (9×1)
         //    lqr_out = [F1, F2, F3, Mz]
@@ -593,12 +690,6 @@ void hover_controller(void *pvParameters)
         // 6. Actuation mapping: [F1, F2, F3, Mz] → [alpha1, alpha2, omega1, omega2, lambda]
         // -----------------------------------------------------------------
         float F_norm  = sqrtf(F1*F1 + F2*F2 + F3*F3);
-        float alpha_1 = 0.0f;
-        float alpha_2 = 0.0f;
-        float omega_1 = 0.0f;
-        float omega_2 = 0.0f;
-        float lambda  = 1.0f; 
-
         // Guard against the zero-gain case (K_hov = 0 until LQR gains are
         // tuned): with no net force commanded the inverse mapping below would
         // divide 0/0 and produce NaNs that would poison the Kalman filter.
@@ -615,6 +706,23 @@ void hover_controller(void *pvParameters)
             float F_2norm = lambda * F_norm;
             omega_2 = sqrtf(fabsf(F_2norm) / KT_ACT);
         }
+#endif
+
+#if MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
+        // Motor thrust is deliberately commanded by the ground station in
+        // this mode. Do not publish unrealized motor-speed requests into the
+        // estimator or imply that altitude control is active.
+        omega_1 = 0.0f;
+        omega_2 = 0.0f;
+#endif
+
+        // Publish the deflection that can actually reach the servos, rather
+        // than allowing the estimator to consume an unclamped request while
+        // the PCA9685 actuator silently applies a smaller angle.
+        const float servo1_limit_rad = servo_max_deflection_1_deg * deg2rad;
+        const float servo2_limit_rad = servo_max_deflection_2_deg * deg2rad;
+        alpha_1 = limit_f(alpha_1, -servo1_limit_rad, servo1_limit_rad);
+        alpha_2 = limit_f(alpha_2, -servo2_limit_rad, servo2_limit_rad);
 
         // -----------------------------------------------------------------
         // 7. Publish actuation output
@@ -626,6 +734,36 @@ void hover_controller(void *pvParameters)
         U_hov.omega2 = omega_2;
         U_hov.lambda = lambda;
         portEXIT_CRITICAL(&global_spinlock);
+
+        const int64_t now_us = esp_timer_get_time();
+        if ((now_us - last_control_log_us) >= 500000) {
+            constexpr float RAD_TO_DEG = 180.0f / static_cast<float>(M_PI);
+            const float alpha1_deg = alpha_1 * RAD_TO_DEG;
+            const float alpha2_deg = alpha_2 * RAD_TO_DEG;
+#if GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+            ESP_LOGI(TAG,
+                     "Gimbal map test: displacement roll=%.2f pitch=%.2f yaw=%.2f deg; gimbal1=%.2f gimbal2=%.2f deg; channel0=%.2f channel7=%.2f deg; motors=0%%",
+                     -error[0] * RAD_TO_DEG,
+                     -error[1] * RAD_TO_DEG,
+                     -error[2] * RAD_TO_DEG,
+                     alpha1_deg,
+                     alpha2_deg,
+                     servo_midpoint_1_deg + servo_direction_1 * alpha1_deg,
+                     servo_midpoint_2_deg + servo_direction_2 * alpha2_deg);
+#else
+            ESP_LOGI(TAG,
+                     "Attitude control: error roll=%.2f pitch=%.2f yaw=%.2f deg; gimbal1=%.2f gimbal2=%.2f deg; channel0=%.2f channel7=%.2f deg; manual throttle=%u%%",
+                     error[0] * RAD_TO_DEG,
+                     error[1] * RAD_TO_DEG,
+                     error[2] * RAD_TO_DEG,
+                     alpha1_deg,
+                     alpha2_deg,
+                     servo_midpoint_1_deg + servo_direction_1 * alpha1_deg,
+                     servo_midpoint_2_deg + servo_direction_2 * alpha2_deg,
+                     motor_power_percent.load());
+#endif
+            last_control_log_us = now_us;
+        }
 
         vTaskDelay(pdMS_TO_TICKS(PERIOD_MS));
     }
@@ -802,8 +940,45 @@ extern "C" void app_main(void)
         vTaskDelay(pdMS_TO_TICKS(1000));
     }
 #elif MOTOR_WIRING_TEST_MODE
-    ESP_LOGW(TAG, "MOTOR_WIRING_TEST_MODE enabled: starting only constant-throttle motor wiring test");
+    ESP_LOGW(TAG, "MOTOR_WIRING_TEST_MODE enabled: starting combined motor/servo bench test");
     ESP_LOGW(TAG, "IMU, GPS, ESP-NOW, BMP390, and control tasks are bypassed");
+
+    // Initialize the FeatherWing independently because normal startup is
+    // bypassed in this isolated test mode.
+    gpio_reset_pin(GPIO_NUM_2);
+    gpio_set_direction(GPIO_NUM_2, GPIO_MODE_OUTPUT);
+    gpio_set_level(GPIO_NUM_2, 1);
+    vTaskDelay(pdMS_TO_TICKS(1000));
+
+    esp_err_t i2c_result = i2c_master_init();
+    if (i2c_result != ESP_OK) {
+        ESP_LOGE(TAG, "Motor/servo test I2C initialization failed: %s",
+                 esp_err_to_name(i2c_result));
+        return;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(100));
+
+    esp_err_t pca_result = pca9685_init();
+    if (pca_result != ESP_OK) {
+        ESP_LOGE(TAG, "Motor/servo test PCA9685 initialization failed: %s",
+                 esp_err_to_name(pca_result));
+        return;
+    }
+
+    // Centre the gimbal before beginning the ESC's five-second zero-throttle
+    // arming period. A zero deflection maps to the configured 110/80 degree
+    // physical servo midpoints.
+    esp_err_t servo_result = tvc_servos_set_deflection_rad(0.0f, 0.0f);
+    if (servo_result != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to centre TVC servos before motor arming: %s",
+                 esp_err_to_name(servo_result));
+        tvc_servo_outputs_disable();
+        return;
+    }
+    ESP_LOGI(TAG, "TVC servos centred at %.1f and %.1f degrees",
+             servo_midpoint_1_deg, servo_midpoint_2_deg);
+    vTaskDelay(pdMS_TO_TICKS(MOTOR_WIRING_TEST_SERVO_CENTER_SETTLE_MS));
 
     estop_triggered = false;
     last_gs_msg_time = 0;
@@ -811,15 +986,95 @@ extern "C" void app_main(void)
     BaseType_t motor_task = xTaskCreatePinnedToCore(init_2_motors, "motor_test", 4096, NULL, 3, NULL, APP_CPU_NUM);
     if (motor_task != pdPASS) {
         ESP_LOGE(TAG, "Failed to create motor wiring test task!");
-    } else {
-        ESP_LOGI(TAG, "Motor wiring test task started.");
+        estop_triggered = true;
+        tvc_servo_outputs_disable();
+        return;
+    }
+    ESP_LOGI(TAG, "Motor wiring test task started; waiting for first successful 5%% frame");
+
+    const int64_t throttle_deadline_us =
+        esp_timer_get_time() + (MOTOR_ARM_ZERO_HOLD_MS + 5000LL) * 1000LL;
+    while (!motor_wiring_test_throttle_active()
+           && esp_timer_get_time() < throttle_deadline_us) {
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
 
-    while (1)
-    {
-        vTaskDelay(pdMS_TO_TICKS(500));
+    if (!motor_wiring_test_throttle_active()) {
+        ESP_LOGE(TAG, "Motor test did not reach 5%% throttle before timeout; aborting");
+        abort_motor_wiring_test();
+        estop_triggered = true;
+        tvc_servo_outputs_disable();
+        while (true) vTaskDelay(pdMS_TO_TICKS(1000));
     }
+
+    ESP_LOGW(TAG,
+             "Both motors running at %d%%; starting servo sweeps of +/-%d degrees",
+             MOTOR_WIRING_TEST_THROTTLE_PERCENT,
+             MOTOR_WIRING_TEST_SERVO_AMPLITUDE_DEG);
+    ESP_LOGI(TAG,
+             "Servo 1 period: %.1f s; servo 2 period: %.1f s; combined pattern: 70 s",
+             MOTOR_WIRING_TEST_SERVO_1_PERIOD_MS / 1000.0f,
+             MOTOR_WIRING_TEST_SERVO_2_PERIOD_MS / 1000.0f);
+
+    constexpr float DEG_TO_RAD = static_cast<float>(M_PI) / 180.0f;
+    constexpr float TWO_PI = 2.0f * static_cast<float>(M_PI);
+    constexpr float SERVO_1_PERIOD_S =
+        MOTOR_WIRING_TEST_SERVO_1_PERIOD_MS / 1000.0f;
+    constexpr float SERVO_2_PERIOD_S =
+        MOTOR_WIRING_TEST_SERVO_2_PERIOD_MS / 1000.0f;
+    const int64_t sweep_start_us = esp_timer_get_time();
+    int64_t last_log_us = sweep_start_us - 1000000LL;
+
+    while (motor_wiring_test_throttle_active()) {
+        const int64_t now_us = esp_timer_get_time();
+        const float elapsed_s =
+            static_cast<float>(now_us - sweep_start_us) / 1000000.0f;
+        const float servo1_deflection_deg = MOTOR_WIRING_TEST_SERVO_AMPLITUDE_DEG
+            * sinf(TWO_PI * elapsed_s / SERVO_1_PERIOD_S);
+        const float servo2_deflection_deg = MOTOR_WIRING_TEST_SERVO_AMPLITUDE_DEG
+            * sinf(TWO_PI * elapsed_s / SERVO_2_PERIOD_S);
+
+        servo_result = tvc_servos_set_deflection_rad(
+            servo1_deflection_deg * DEG_TO_RAD,
+            servo2_deflection_deg * DEG_TO_RAD);
+        if (servo_result != ESP_OK) {
+            ESP_LOGE(TAG, "Servo sweep failed: %s; aborting motor test",
+                     esp_err_to_name(servo_result));
+            abort_motor_wiring_test();
+            break;
+        }
+
+        if ((now_us - last_log_us) >= 1000000LL) {
+            ESP_LOGI(TAG,
+                     "Bench sweep: servo1=%.1f deg, servo2=%.1f deg",
+                     servo_midpoint_1_deg
+                         + servo_direction_1 * servo1_deflection_deg,
+                     servo_midpoint_2_deg
+                         + servo_direction_2 * servo2_deflection_deg);
+            last_log_us = now_us;
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(20)); // 50 Hz servo update
+    }
+
+    estop_triggered = true;
+    abort_motor_wiring_test();
+    tvc_servo_outputs_disable();
+    ESP_LOGE(TAG, "Combined motor/servo bench test aborted; motor zeroed and servos disabled");
+    while (true) vTaskDelay(pdMS_TO_TICKS(1000));
 #else
+#if MANUAL_THROTTLE_ATTITUDE_ONLY_MODE
+#if GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+    ESP_LOGW(TAG,
+             "Gimbal attitude mapping test: ARM captures neutral; roll->gimbal1 and pitch->gimbal2 at 1:1; motors locked at 0%%");
+#else
+    ESP_LOGW(TAG,
+             "Flight mode: manual ground-station throttle with closed-loop TVC attitude control");
+    ESP_LOGW(TAG,
+             "Altitude actuation, controller motor-speed output, and horizontal-position control are disabled");
+#endif
+#endif
+
     //enable power to the STEMMA QT connector (I2C power) early
     ESP_LOGI(TAG, "Enabling STEMMA QT power (GPIO 2)...");
     gpio_reset_pin(GPIO_NUM_2);
@@ -846,6 +1101,21 @@ extern "C" void app_main(void)
         return;
     }
 
+    // Normal startup begins ESTOP'd. Explicitly remove pulses from both TVC
+    // channels now so a separately powered PCA9685 cannot retain stale output
+    // while the remaining sensors and control tasks initialize.
+    esp_err_t servo1_off_result =
+        pca9685_set_channel_off(TVC_SERVO_1_CHANNEL);
+    esp_err_t servo2_off_result =
+        pca9685_set_channel_off(TVC_SERVO_2_CHANNEL);
+    if (servo1_off_result != ESP_OK || servo2_off_result != ESP_OK) {
+        ESP_LOGE(TAG,
+                 "Failed to disable TVC servos during startup (servo1: %s, servo2: %s)",
+                 esp_err_to_name(servo1_off_result),
+                 esp_err_to_name(servo2_off_result));
+        return;
+    }
+
     if (servo_testing_mode.load()) {
         ESP_LOGW(TAG, "servo_testing_mode=true. Entering blocking servo test loop before other init.");
         servo_test_via_serial_blocking();
@@ -855,7 +1125,20 @@ extern "C" void app_main(void)
         }
     }
 
-    bmp390_init();
+    esp_err_t bmp_result = bmp390_init();
+    if (bmp_result != ESP_OK) {
+        ESP_LOGE(TAG, "BMP390 initialization failed: %s",
+                 esp_err_to_name(bmp_result));
+        return;
+    }
+
+    ESP_LOGI(TAG, "Calibrating launch altitude; keep the vehicle stationary...");
+    bmp_result = bmp390_calibrate_altitude_zero(20, 50);
+    if (bmp_result != ESP_OK) {
+        ESP_LOGE(TAG, "Launch-altitude calibration failed: %s",
+                 esp_err_to_name(bmp_result));
+        return;
+    }
     init_espnow_sender();
 
     // Start UART for GPS and hook the correction callback
@@ -882,7 +1165,8 @@ extern "C" void app_main(void)
     // Launch state estimation task
     BaseType_t state_estimation_task = xTaskCreatePinnedToCore(state_estimation, "state estimation", 8192, NULL, 2, NULL, APP_CPU_NUM);
     if(state_estimation_task != pdPASS) {
-        ESP_LOGE(TAG, "Failed to create state estimation task!");
+        ESP_LOGE(TAG, "Failed to create state estimation task; actuator startup aborted");
+        return;
     } else {
         ESP_LOGI(TAG, "State estimation task started.");
     }
@@ -890,7 +1174,8 @@ extern "C" void app_main(void)
     // Launch position controller task (LQR outer loop, 50 Hz)
     BaseType_t pos_ctrl_task = xTaskCreatePinnedToCore(position_controller, "pos_ctrl", 4096, NULL, 2, NULL, APP_CPU_NUM);
     if(pos_ctrl_task != pdPASS) {
-        ESP_LOGE(TAG, "Failed to create position controller task!");
+        ESP_LOGE(TAG, "Failed to create position controller task; actuator startup aborted");
+        return;
     } else {
         ESP_LOGI(TAG, "Position controller task started.");
     }
@@ -898,10 +1183,24 @@ extern "C" void app_main(void)
     // Launch hover controller task (LQR inner loop, 50 Hz)
     BaseType_t hov_ctrl_task = xTaskCreatePinnedToCore(hover_controller, "hov_ctrl", 4096, NULL, 2, NULL, APP_CPU_NUM);
     if(hov_ctrl_task != pdPASS) {
-        ESP_LOGE(TAG, "Failed to create hover controller task!");
+        ESP_LOGE(TAG, "Failed to create hover controller task; actuator startup aborted");
+        return;
     } else {
         ESP_LOGI(TAG, "Hover controller task started.");
     }
+
+    // Keep blocking PCA9685 writes out of the hover-control calculation. The
+    // actuator task reads U_hov, applies calibrated servo offsets/limits, and
+    // enables outputs only while software ESTOP is clear.
+    BaseType_t servo_actuation_task = xTaskCreatePinnedToCore(
+        tvc_servo_actuation_task, "tvc_servo_actuation", 4096,
+        NULL, 2, NULL, APP_CPU_NUM);
+    if (servo_actuation_task != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create TVC servo actuation task; halting startup");
+        return;
+    }
+    ESP_LOGI(TAG, "TVC servo actuation task started.");
+
     BaseType_t motor_task = xTaskCreatePinnedToCore(init_2_motors, "initialize 2 motors", 4096, NULL, 3, NULL, APP_CPU_NUM);
     if(motor_task != pdPASS) {
         ESP_LOGE(TAG, "Failed to create motor task!");

--- a/lander/main/motor_init.cpp
+++ b/lander/main/motor_init.cpp
@@ -4,6 +4,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "globalvars.hpp"
+#include <atomic>
 
 // Include the DShot library
 #include "DShotRMT.h"
@@ -16,17 +17,33 @@ struct motor_pin_change_request_t {
 };
 
 static QueueHandle_t motor_pin_change_queue = nullptr;
+static std::atomic<bool> wiring_test_throttle_active{false};
+static std::atomic<bool> wiring_test_abort_requested{false};
+
+bool motor_wiring_test_throttle_active()
+{
+    return wiring_test_throttle_active.load();
+}
+
+void abort_motor_wiring_test()
+{
+    wiring_test_abort_requested = true;
+    wiring_test_throttle_active = false;
+}
 
 // DShot reserves values 0-47 for stop and special commands. Values 48-2047
 // represent the usable throttle range.
+#if !GIMBAL_ATTITUDE_MAPPING_TEST_MODE
 static constexpr uint16_t MIN_THROTTLE = 48;
 static constexpr uint16_t MAX_THROTTLE = 2047;
+#endif
 
 // Global ESC instances allow an ESTOP-gated ground-station command to move a
 // motor output to another safe GPIO during bench work.
 static DShotRMT global_esc1;
 static DShotRMT global_esc2;
 
+#if !GIMBAL_ATTITUDE_MAPPING_TEST_MODE
 static uint16_t power_percent_to_throttle(uint8_t power_percent)
 {
     // Zero is a distinct DShot stop command, not the bottom of the 48-2047
@@ -43,6 +60,7 @@ static uint16_t power_percent_to_throttle(uint8_t power_percent)
         + static_cast<uint16_t>(
             (power_percent * (MAX_THROTTLE - MIN_THROTTLE)) / 100);
 }
+#endif
 
 // Reject pins unsafe for DShot before tearing down the old pin: 34-39
 // (input-only), 6-11 (flash), 0/12/15 (strapping), 1/3 (UART0), 2 (sensor power).
@@ -159,6 +177,11 @@ static esp_err_t hold_both_zero_ms(uint32_t duration_ms)
 
 void init_2_motors(void* pvParameters)
 {
+#if MOTOR_WIRING_TEST_MODE
+    wiring_test_throttle_active = false;
+    wiring_test_abort_requested = false;
+#endif
+
     // Physical motor mapping for the current counter-rotating propeller stack:
     //   ESC 1 / GPIO 4  = bottom propeller
     //   ESC 2 / GPIO 25 = top propeller
@@ -246,6 +269,9 @@ void init_2_motors(void* pvParameters)
              "MOTOR_WIRING_TEST_MODE enabled: ignoring ground-station timeout and software ESTOP");
     ESP_LOGW(TAG, "Fixed bench-test throttle: %d%%",
              MOTOR_WIRING_TEST_THROTTLE_PERCENT);
+#elif GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+    ESP_LOGW(TAG,
+             "GIMBAL_ATTITUDE_MAPPING_TEST_MODE enabled: both motors locked at 0%% throttle");
 #endif
 
     bool logged_first_throttle = false;
@@ -285,8 +311,21 @@ void init_2_motors(void* pvParameters)
 #endif
 
 #if MOTOR_WIRING_TEST_MODE
+        if (wiring_test_abort_requested.load()) {
+            global_esc1.sendThrottle(0);
+            global_esc2.sendThrottle(0);
+            wiring_test_throttle_active = false;
+            vTaskDelay(pdMS_TO_TICKS(10));
+            continue;
+        }
+
         const uint16_t throttle_value =
             power_percent_to_throttle(MOTOR_WIRING_TEST_THROTTLE_PERCENT);
+#elif GIMBAL_ATTITUDE_MAPPING_TEST_MODE
+        // This validation exercises only the IMU-to-gimbal direction. Keep
+        // sending valid zero-throttle frames so no ground-station command can
+        // accidentally introduce thrust during the hands-on tilt test.
+        const uint16_t throttle_value = 0;
 #else
         const uint16_t throttle_value =
             power_percent_to_throttle(motor_power_percent.load());
@@ -307,9 +346,17 @@ void init_2_motors(void* pvParameters)
             global_esc2.sendThrottle(0);
             motor_power_percent = 0;
             estop_triggered = true;
+#if MOTOR_WIRING_TEST_MODE
+            abort_motor_wiring_test();
+#endif
         }
 
         if (!logged_first_throttle) {
+#if MOTOR_WIRING_TEST_MODE
+            if (result1 == ESP_OK && result2 == ESP_OK) {
+                wiring_test_throttle_active = true;
+            }
+#endif
             ESP_LOGI(TAG, "Finished first throttle frame for both motors");
             logged_first_throttle = true;
         }

--- a/lander/main/motor_init.hpp
+++ b/lander/main/motor_init.hpp
@@ -4,13 +4,36 @@
 #include "driver/gpio.h"
 #include <stdint.h>
 
-// Temporary motor wiring test mode.
-// When enabled, app_main starts only the motor task, and the motor task ignores
-// ground-station ESTOP/heartbeat state and commands a fixed 5% throttle. Keep
-// the mode disabled for normal builds; enable it only for a controlled bench
+// Temporary combined motor/servo bench-test mode. When enabled, app_main
+// centres both TVC servos, arms both ESCs at zero, commands a fixed 5%
+// throttle, then sweeps the servos around their configured midpoints. Normal
+// sensor, control, ground-station ESTOP, and heartbeat handling are bypassed.
+// Keep this disabled for normal builds; enable it only for a controlled bench
 // test with the vehicle restrained and the propeller area clear.
 #define MOTOR_WIRING_TEST_MODE 0
 #define MOTOR_WIRING_TEST_THROTTLE_PERCENT 5
+#define MOTOR_WIRING_TEST_SERVO_AMPLITUDE_DEG 10
+#define MOTOR_WIRING_TEST_SERVO_1_PERIOD_MS 7000
+#define MOTOR_WIRING_TEST_SERVO_2_PERIOD_MS 10000
+#define MOTOR_WIRING_TEST_SERVO_CENTER_SETTLE_MS 1000
+
+// First tethered-flight configuration: the ground station commands identical
+// collective throttle to both motors while the hover controller commands only
+// the TVC servos. Altitude and calculated motor-speed outputs are intentionally
+// excluded until an omega-to-DShot/thrust calibration is available.
+#define MANUAL_THROTTLE_ATTITUDE_ONLY_MODE 1
+
+// Temporary zero-thrust hardware validation mode. ARM captures the current
+// attitude, then roll displacement maps 1:1 to gimbal 1 and pitch displacement
+// maps 1:1 to gimbal 2 using the model's corrective direction convention.
+// Ground-station throttle commands are rejected and both ESCs remain at zero.
+// Disable this after verifying the physical IMU-to-gimbal directions so the
+// normal hover LQR and force-to-gimbal mapping run again.
+#define GIMBAL_ATTITUDE_MAPPING_TEST_MODE 0
+
+#if GIMBAL_ATTITUDE_MAPPING_TEST_MODE && MOTOR_WIRING_TEST_MODE
+#error "GIMBAL_ATTITUDE_MAPPING_TEST_MODE and MOTOR_WIRING_TEST_MODE cannot both be enabled"
+#endif
 
 // BLHeli_S ESCs need about five seconds of valid zero-throttle DShot frames
 // before they accept throttle commands.
@@ -28,5 +51,7 @@
 void init_2_motors(void* pvParameters);
 void reinit_motor_pin(uint8_t motor_idx, gpio_num_t new_pin);
 void request_motor_pin_change(uint8_t motor_idx, gpio_num_t new_pin);
+bool motor_wiring_test_throttle_active();
+void abort_motor_wiring_test();
 
 #endif // MOTOR_INIT_HPP


### PR DESCRIPTION
Add a dedicated 50 Hz PCA9685 actuator path for channels 0 and 7. Apply the hardware-validated 110/80 degree midpoints, invert both installed servos, clamp each gimbal to +/-13 degrees, remove PWM during ESTOP, and latch ESTOP on invalid commands or output failures.

Restore the compiled hover gain matrix and make manual-throttle attitude-only control the default tethered mode. The ground station commands equal DShot throttle while the LQR controls the gimbals; altitude terms, horizontal-position output, and unrealized controller motor speeds are explicitly excluded.

Add three isolated validation paths: a zero-thrust 1:1 roll/pitch-to-gimbal direction test, a combined 5 percent motor and dual-period servo sweep, and a terminal-controlled servo calibration mode. Keep every test mode disabled by default and retain optional temporary DShot motor reversal.

Coordinate ARM and ZERO_IMU around a captured attitude reference, launch-relative BMP390 zero, Kalman reset, controller reset, and zero-throttle arming checks. Arm both ESCs simultaneously and retain ESTOP and 500 ms link-loss protection.

Rate-limit state and controller diagnostics, report both controller deflections and absolute servo angles, and remove per-packet ESP-NOW TX spam.

Document the current switches, wiring, startup sequence, safety behaviour, test procedures, expected commands, hardware validation, and remaining pre-flight limitations.

Verified with ESP-IDF 6.0.2 using ninja -C lander/build. Hardware checks confirmed startup, DShot, ARM/ESTOP/link failsafe, both servo inversions, midpoints, travel, and zero-thrust corrective direction. Powered tethered LQR response and the unsigned gimbal-2 acos inverse mapping remain to be validated.